### PR TITLE
Add overview calculations for same dice eyes

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -1,15 +1,26 @@
 /**
   * Renders game overview
   */
-const renderOverviewContainer = (container) => {
+const renderOverviewContainer = () => {
     const overview = document.getElementById("overview");
-    overview.onclick = event => console.log(event);
+    overview.innerHTML = "";
+    overview.onclick = lockOverviewField
 
-    container.forEach(item => {
+    scoreFields.forEach(item => {
         const sameEyesContainer = document.createElement("div");
+        let pointsId = "";
+
+        if (item.index !== undefined) {
+            sameEyesContainer.setAttribute("index", item.index);
+            pointsId = `id="points-${item.index}"`;
+
+        }
+        if (item.locked == true) {
+            sameEyesContainer.classList.add("locked");
+        }
         sameEyesContainer.innerHTML = `
             <span class="${item.class || 'pointer'}">${item.text}</span>
-            <span class="${item.class || 'pointer'}">${item.score}</span>`
+            <span ${pointsId} class="${item.class || 'pointer'}">${item.locked ? item.score : ""}</span>`
         overview.appendChild(sameEyesContainer);
     });
 }
@@ -43,10 +54,7 @@ const renderDice = () => {
  */
 const mainRenderer = () => {
     // render UI
-    renderOverviewContainer(scoreFieldsSameEyes);
-    renderOverviewContainer(scoreFieldsSum);
-    renderOverviewContainer(scoreFieldsDifferent);
-    renderOverviewContainer(totalScore);
+    renderOverviewContainer();
 
     // add event listen to button
     document.getElementById("roll").onclick = rollDiceHandler;

--- a/src/variables.js
+++ b/src/variables.js
@@ -1,42 +1,35 @@
 /**
  * Data
  */
-const scoreFieldsSameEyes = [
-    {
-        text: "Ones",
-        score: 0
-    },
-    {
-        text: "Twos",
-        score: 0
-    },
-    {
-        text: "Threes",
-        score: 0
-    },
-    {
-        text: "Fours",
-        score: 0
-    },
-    {
-        text: "Fives",
-        score: 0
-    },
-    {
-        text: "Sixes",
-        score: 0
-    }
-];
+const scoreFields = [];
+const boardDice = [];
+let round = 0;
+let scoreFieldLocked = false;
+
+const amountOfDiceInGame = 5;
+
+const diceNames = {
+    1: "one",
+    2: "two",
+    3: "three",
+    4: "four",
+    5: "five",
+    6: "six"
+};
 
 const scoreFieldsSum = [
     {
         text: "Sum",
         score: 0,
+        index: 6,
+        locked: true,
         class: "border-top bold"
     },
     {
         text: "Bonus",
         score: 0,
+        index: 7,
+        locked: true,
         class: "border-bottom bold"
     }
 ];
@@ -44,31 +37,38 @@ const scoreFieldsSum = [
 const scoreFieldsDifferent = [
     {
         text: "Three of a kind",
-        score: 0
+        score: 0,
+        action: () => {},
     },
     {
         text: "Four of a kind",
-        score: 0
+        score: 0,
+        action: () => {},
     },
     {
         text: "Full house",
-        score: 0
+        score: 0,
+        action: () => {},
     },
     {
         text: "Small straight",
-        score: 0
+        score: 0,
+        action: () => {},
     },
     {
         text: "Large straight",
-        score: 0
+        score: 0,
+        action: () => {},
     },
     {
         text: "Chance",
-        score: 0
+        score: 0,
+        action: () => {},
     },
     {
         text: "Yatzy",
-        score: 0
+        score: 0,
+        action: () => {},
     },
 ];
 
@@ -80,17 +80,31 @@ totalScore = [
     }
 ];
 
-const diceNames = {
-    1: "one",
-    2: "two",
-    3: "three",
-    4: "four",
-    5: "five",
-    6: "six"
-};
 
-const boardDice = []
+/**
+ * generate list of score fields
+ */
+const generateScoreFields = () => {
+    // same eyes
+    for (let i = 1; i <= amountOfDiceInGame; i++) {
+        scoreFields.push({
+            text: diceNames[i] + "s",
+            score: 0,
+            index: i-1,
+            locked: false,
+            action: () => calculateSameEyedDice(i)
+        });
+    }
 
-const amountOfDiceInGame = 5;
+    for (let field of scoreFieldsSum) {
+        scoreFields.push(field);
+    }
 
-let round = 0;
+    const fieldIndexCounter = amountOfDiceInGame + 2;
+
+    for (let i = fieldIndexCounter; i < fieldIndexCounter + scoreFieldsDifferent.length; i++) {
+        scoreFields.push(scoreFieldsDifferent[i - fieldIndexCounter]);
+        scoreFields[i].index = i;
+    }
+}
+generateScoreFields();

--- a/src/yatzy.css
+++ b/src/yatzy.css
@@ -68,7 +68,7 @@ span {
     padding-left: 15px;
 }
 
-.locked {
+.locked span {
     background-color: lightblue;
 }
 

--- a/src/yatzy.js
+++ b/src/yatzy.js
@@ -2,6 +2,10 @@
  * Board logic
  */
 const selectDie = (event) => {
+    if (round == 0) {
+        return;
+    }
+
     let target;
 
     if (event.target.className == "eye") {
@@ -14,6 +18,11 @@ const selectDie = (event) => {
     boardDice[index].locked = !boardDice[index].locked;
 }
 
+const changeRound = newRound => {
+    round = newRound;
+    document.getElementById("round-counter").innerText = round;
+}
+
 /**
  * Rolling dice
  */
@@ -21,18 +30,78 @@ const rollDiceHandler = () => {
     if (round < 3) {
         rollDice();
         renderDice();
-        round++;
-        document.getElementById("round-counter").innerText = round;
+        changeRound(round + 1);
+        renderOverviewContainer();
+        updateOverviewTempScores();
+        scoreFieldLocked = false;
     }
 }
 
 const rollDice = () => {
-for (let i = 0; i < amountOfDiceInGame; i++) {
-    if (!boardDice[i] || boardDice[i] && !boardDice[i].locked) {
-        boardDice[i] = {
-            eyes: parseInt(Math.random()*5+1),
-            locked: false
-        };
+    for (let i = 0; i < amountOfDiceInGame; i++) {
+        if (!boardDice[i] || boardDice[i] && !boardDice[i].locked) {
+            boardDice[i] = {
+                eyes: parseInt(Math.random()*5+1),
+                locked: false
+            };
+        }
     }
 }
+
+/**
+ * Overview logic
+ */
+
+const lockOverviewField = (event) => {
+    if (scoreFieldLocked === true) {
+        return;
+    }
+
+    const index = event.target.parentElement.getAttribute("index");
+    if (index !== undefined && round != 0 && !scoreFields[index].locked) {
+        scoreFields[index].locked = true;
+        scoreFields[index].score = scoreFields[index].action();
+        changeRound(0);
+
+        if (scoreFields[index].action !== undefined) {
+            renderOverviewContainer();
+        }
+        calculateSameEyesSum();
+    }
+
+    Array.from(document.getElementsByClassName("selected")).forEach(dice => {
+        const index = dice.getAttribute("index");
+        dice.classList.toggle("selected");
+        boardDice[index].locked = !boardDice[index].locked;
+    });
+}
+
+// Same eyed dice calculations
+const calculateSameEyedDice = amount => {
+    const total = boardDice
+        .filter(item => item.eyes === amount)
+        .map(item => item.eyes)
+        .reduce((a,b) => a + b, 0);
+
+    document.getElementById("points-" + (amount - 1)).innerText = total;
+    return total;
+}
+
+const calculateSameEyesSum = () => {
+    let total = 0;
+
+    for (let i = 0; i < 5; i++) {
+        total += scoreFields[i].score;
+    }
+
+    scoreFields[5].score = total;
+    document.getElementById("points-6").innerText = total;
+}
+
+const updateOverviewTempScores = () => {
+    for (field of scoreFields) {
+        if (field.action != undefined && !field.locked) {
+            field.action();
+        }
+    }
 }


### PR DESCRIPTION
- add index to score fields
- add locked to score fields
- fix CSS for locked rows
- move all score fields into one collection of score fields
- add value to track amount of dice in the game
- add actions to score fields
- add method to generate dice objects
- lock die selection on round 0
- add method to change round
- update round counter and rerender score overview on roll
- add method to lock score field
:: when a score field is locked, the score will be udpated in the
object, all selected dice will be deselected, the overview will be
rerendered, the sum is calculated::
- add method to calculate sum of same eye dice
- add method to update all scores temporary based on the dice rolled